### PR TITLE
fix(app): prevent TensorFlow training callback crash

### DIFF
--- a/app/src/app/utils/colorUtils.js
+++ b/app/src/app/utils/colorUtils.js
@@ -150,7 +150,9 @@ export const trainModel = async (
 
     const callbacks = [earlyStoppingCallback];
     if (typeof onEpochEnd === 'function') {
-      callbacks.push({ onEpochEnd });
+      callbacks.push(tf.customCallback({
+        onEpochEnd,
+      }));
     }
     
     const history = await model.fit(tensors.xs, tensors.ys, {


### PR DESCRIPTION
## Summary
- fix the TensorFlow.js training regression by wrapping the epoch progress handler with `tf.customCallback(...)`
- preserve early stopping and progress updates without passing an invalid plain object into the callbacks array
- prevent the runtime training failure `t.setParams is not a function`