### PR TITLE
fix(app): restore TensorFlow.js training callback compatibility

### DIFF
--- a/app/src/app/utils/colorUtils.js
+++ b/app/src/app/utils/colorUtils.js
@@ -148,12 +148,12 @@ export const trainModel = async (
       mode: 'min'
     });
 
-    const callbacks = [earlyStoppingCallback];
-    if (typeof onEpochEnd === 'function') {
-      callbacks.push(tf.customCallback({
-        onEpochEnd,
-      }));
-    }
+    const callbacks = typeof onEpochEnd === 'function'
+      ? {
+          onEpochEnd,
+          callbacks: [earlyStoppingCallback],
+        }
+      : [earlyStoppingCallback];
     
     const history = await model.fit(tensors.xs, tensors.ys, {
       epochs,


### PR DESCRIPTION
## Summary
- replace the unsupported `tf.customCallback(...)` usage with the callback object shape supported by this installed TensorFlow.js build
- preserve both epoch progress updates and early stopping during model training
- prevent the browser runtime error `customCallback is not a function`