### PR TITLE
fix(app): preserve prediction until the color changes

### DIFF
--- a/app/src/app/page.js
+++ b/app/src/app/page.js
@@ -595,10 +595,10 @@ export default function ColorPredictor() {
   }, []);
 
   useEffect(() => {
-    if (status.isPredicting) return;
+    if (status.isPredicting || !predictionTargetColor || currentColor === predictionTargetColor) return;
     setPrediction(null);
     setPredictionTargetColor(null);
-  }, [currentColor, status.isPredicting]);
+  }, [currentColor, predictionTargetColor, status.isPredicting]);
 
   useEffect(() => {
     if (!showClearDialog) return;


### PR DESCRIPTION
## Summary
- fix the stale-prediction cleanup so successful predictions remain visible after analysis completes
- only clear a prediction when the selected color actually changes away from the prediction target
- prevent the prediction result card from disappearing immediately after it appears