### PR TITLE
docs: replace outdated README and add missing LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2021 Andres Caicedo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,118 @@
 # Color Predictor
 
-## Overview
+Teach a small neural network your color taste — entirely in your browser. No data
+ever leaves your device.
 
-Color Predictor is a simple web application designed to learn and predict your favorite colors. It provides a user-friendly interface where users can interact and discover their color preferences.
+**[▶ Try the live demo](https://andrescdo.github.io/color-predictor/)**
+
+[![Deploy to GitHub Pages](https://github.com/AndresCdo/color-predictor/actions/workflows/deploy.yml/badge.svg)](https://github.com/AndresCdo/color-predictor/actions/workflows/deploy.yml)
+
+## How it works
+
+1. **Rate colors.** Pick a color and mark it as liked or disliked. Each rating
+   becomes a labeled training example.
+2. **Train.** Once you have at least 2 liked and 2 disliked colors, training
+   runs in the browser with TensorFlow.js.
+3. **Predict.** The model classifies any new color as _like_ or _dislike_ and
+   reports its confidence.
+
+Everything — training, inference, and storage — happens client-side. There is no
+backend and no telemetry.
+
+## The model
+
+A small binary classifier defined in [`app/src/app/utils/colorUtils.js`](app/src/app/utils/colorUtils.js):
+
+| Stage            | Configuration                                                             |
+| ---------------- | ------------------------------------------------------------------------- |
+| Input            | 3 features — RGB channels normalized to `[0, 1]`                          |
+| Hidden 1         | Dense 32 (Glorot normal) → BatchNorm → ReLU → Dropout 0.2                 |
+| Hidden 2         | Dense 16 (Glorot normal) → BatchNorm → ReLU → Dropout 0.2                 |
+| Output           | Dense 1, sigmoid                                                          |
+| Loss / optimizer | Binary cross-entropy / Adam (lr `0.001`)                                  |
+| Training         | 50 epochs, batch size 32, 20% validation split, shuffled                  |
+| Regularization   | Dropout plus early stopping on `val_loss` (min delta `0.001`, patience 5) |
+
+Confidence is derived from the distance to the decision boundary:
+`|score − 0.5| × 2`.
+
+## Persistence
+
+- The trained model is saved to **IndexedDB** (`indexeddb://color-predictor-v1`)
+  and reloaded automatically on the next visit.
+- Ratings, rating history, theme preference, and training stats are kept in
+  **localStorage**.
+- _Clear session_ removes the ratings and stats; the saved model stays on the
+  device until browser data is cleared.
 
 ## Features
 
-- **Simple and Intuitive UI:** The application boasts a clean and straightforward user interface, making it accessible for users of all ages.
-- **Color Prediction:** Leverages advanced algorithms to predict and suggest colors that you might like.
+- Color picker with a hex input, validation, and a random-color button.
+- Keyboard shortcuts: <kbd>L</kbd> like, <kbd>D</kbd> dislike, <kbd>U</kbd> undo,
+  <kbd>T</kbd> train, <kbd>P</kbd> predict.
+- Live training progress with per-epoch accuracy.
+- Light, dark, and system theme modes.
+- Accessibility: ARIA live regions for status changes, a focus-trapped
+  confirmation dialog, labelled controls, and swatch text contrast computed from
+  relative luminance.
 
-## Getting Started
+## Tech stack
 
-To get started with the Color Predictor, follow these steps:
+- [Next.js 15](https://nextjs.org/) (App Router, static export)
+- [React 19](https://react.dev/)
+- [TensorFlow.js 4](https://www.tensorflow.org/js)
+- CSS Modules
 
-1. **Clone the Repository**
-   - Use `git clone` followed by the repository URL to clone the project onto your local machine.
+## Running locally
 
-2. **Open the Project**
-   - Open the project folder in your preferred code editor or IDE.
+Requires Node.js 20 or newer.
 
-3. **Launch the Application**
-   - Open the `main.html` file in a web browser to start the application.
+```bash
+git clone https://github.com/AndresCdo/color-predictor.git
+cd color-predictor/app
+npm install
+npm run dev
+```
 
-## Technologies Used
+The dev server runs at <http://localhost:3000/color-predictor>.
 
-- HTML5
-- CSS3
+Available scripts, all run from `app/`:
+
+| Command         | Purpose                           |
+| --------------- | --------------------------------- |
+| `npm run dev`   | Development server with Turbopack |
+| `npm run build` | Static export to `app/out/`       |
+| `npm run lint`  | ESLint via `eslint-config-next`   |
+
+## Deployment
+
+Pushing to `master` triggers
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml), which builds the
+static export and publishes `app/out/` to GitHub Pages.
+
+Because Pages serves the site from a subpath, `app/next.config.mjs` sets
+`basePath: '/color-predictor'` alongside `output: 'export'`.
+
+## Project structure
+
+```
+app/
+├── next.config.mjs              # Static export + basePath for GitHub Pages
+└── src/app/
+    ├── page.js                  # Main UI, training and prediction flow
+    ├── layout.js
+    ├── components/ColorPicker.js
+    └── utils/colorUtils.js      # Model definition, training, prediction, persistence
+.github/workflows/deploy.yml     # Build and deploy to GitHub Pages
+Dockerfile                       # Container build
+conf/                            # nginx configuration
+```
 
 ## Contributing
 
-We welcome contributions to the Color Predictor project. If you have suggestions or improvements, please fork the repository and submit a pull request.
+Issues and pull requests are welcome. Please keep changes focused and run
+`npm run lint` from `app/` before opening a pull request.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Why

The README described a version of this project that no longer exists:

- It listed the tech stack as **"HTML5, CSS3"**. The app is Next.js 15 +
  React 19 + TensorFlow.js 4.
- Its quickstart said *"Open the `main.html` file in a web browser"*.
  **`main.html` is not in the repository**, so the documented way to run the
  project could not work.
- It stated *"see the LICENSE file"*, but **no LICENSE file had ever been
  committed** — GitHub reported this repository as having no license.
- It never linked the live demo, even though
  https://andrescdo.github.io/color-predictor/ is deployed and working.

## What changed

- **`README.md`** rewritten from the actual source. Every claim is taken from
  the code: model topology and training configuration from
  `app/src/app/utils/colorUtils.js`, the training threshold and keyboard
  shortcuts from `app/src/app/page.js`, scripts from `app/package.json`, and
  the deployment description from `.github/workflows/deploy.yml` plus
  `app/next.config.mjs`.
- Live demo link and deploy workflow badge added at the top.
- **`LICENSE`** added (MIT), matching `"license": "MIT"` in `package.json` and
  the claim the README was already making.

## Please review

- **The LICENSE file is a proposal.** It is MIT with `Copyright (c) 2021
  Andres Caicedo` — 2021 is the year of the first commit in this repository.
  Drop that file from this PR if you would rather license it differently.
- Every path referenced by the README was checked to exist.

## Not addressed here

Two pre-existing issues found while writing this, left out to keep the PR
focused:

1. The **root `package.json`** is leftover from the old version: it declares
   `"main": "main.js"`, `"start": "node tf.js"` and `"build": "webpack"`, and
   depends on `express` and `@tensorflow/tfjs@^3.10.1`. None of those files or
   tools exist in the repo; the real project lives in `app/`.
2. The **`Dockerfile`** runs `npm run start` (`next start`) and healthchecks
   `/api/health`, but `app/next.config.mjs` sets `output: 'export'`, which
   produces a static site with no server and no API routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
